### PR TITLE
do not activate the form if MinimumSize changes.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -1447,7 +1447,7 @@ namespace System.Windows.Forms
                             Location.Y,
                             Size.Width,
                             Size.Height,
-                            User32.SWP.NOZORDER);
+                            User32.SWP.NOZORDER | User32.SWP.NOACTIVATE);
                     }
 
                     OnMinimumSizeChanged(EventArgs.Empty);


### PR DESCRIPTION
in DPIScalebleForm we scale the MinSize/MaxSize when DPI changes (because this does not happen in framework for some reason I do not understand)
Changing MinSize activates the form, which looks up the ActiveControl to set focus to. But dpi change arrives too early and the control is not visible yet, so ActiveControl remains null on nonprimary screen, but works fine on the primary one

https://emclient.atlassian.net/browse/EC-5671